### PR TITLE
added option to resolve DNS of host manually

### DIFF
--- a/telegram
+++ b/telegram
@@ -211,7 +211,7 @@ function escapeMarkdown {
 	echo "$res"
 }
 
-while getopts "t:c:i:f:V:MHCrhlvjnRmDNTI:" opt; do
+while getopts "t:c:i:f:V:MHCrhlvjnRmDNIT:" opt; do
 	case $opt in
 		t)
 			TOKEN="$OPTARG"
@@ -271,7 +271,7 @@ while getopts "t:c:i:f:V:MHCrhlvjnRmDNTI:" opt; do
 			;;
 		I)
 			TELEGRAM_HOST=`echo "$URL" | sed 's,https://,,;s,/bot,,'`
-			TELEGRAM_IP=`dig @8.8.8.8 $TELEGRAM_HOST | grep "ANSWER SECTION" -A 2 | grep -v -e CNAME  -e "ANSWER SECTION" | cut -f5`
+			TELEGRAM_IP=`dig @8.8.8.8 $TELEGRAM_HOST +short`
 			CURL_OPTIONS="$CURL_OPTIONS --resolve ${URL%/bot}:$TELEGRAM_IP"
 			;;
 		?|h)

--- a/telegram
+++ b/telegram
@@ -53,6 +53,7 @@ function help {
 	echo "    -C               Sends text as monospace code. Useful when piping command outputs into this tool."
 	echo "    -r               Like -C, but if the first line starts with '+ ', it is specially formatted."
 	echo "    -T <TITLE>       Sets a title for the message. Printed in bold text if -M or -H is used."
+	echo "    -I               Resolves the IP of the Telegram API Host manually by using Google DNS to mitigate DNS issues."
 	echo "    -l               Fetch known chat_ids."
 	echo "    -R               Receive a file sent via telegram."
 	echo "    -D               Sets disable_web_page_preview parameter to, well, disable the preview for links to webpages."
@@ -210,7 +211,7 @@ function escapeMarkdown {
 	echo "$res"
 }
 
-while getopts "t:c:i:f:V:MHCrhlvjnRmDNT:" opt; do
+while getopts "t:c:i:f:V:MHCrhlvjnRmDNTI:" opt; do
 	case $opt in
 		t)
 			TOKEN="$OPTARG"
@@ -267,6 +268,11 @@ while getopts "t:c:i:f:V:MHCrhlvjnRmDNT:" opt; do
 			;;
 		T)
 			TITLE="$OPTARG"
+			;;
+		I)
+			TELEGRAM_HOST=`echo "$URL" | sed 's,https://,,;s,/bot,,'`
+			TELEGRAM_IP=`dig @8.8.8.8 $TELEGRAM_HOST | grep "ANSWER SECTION" -A 2 | grep -v -e CNAME  -e "ANSWER SECTION" | cut -f5`
+			CURL_OPTIONS="$CURL_OPTIONS --resolve ${URL%/bot}:$TELEGRAM_IP"
 			;;
 		?|h)
 			help


### PR DESCRIPTION
As I use this script to send telegram alerts when parts of my infrastructure are unavailable it may coincide with the Pihole DNS server to be offline. When this happens there is no DNS resolution of the Telegram host and no message can be send. To alleviate this issue I have introduced a new flag (-I) which resolves the host by using the Google DNS 8.8.8.8 instead of using the usual DNS.